### PR TITLE
chore: ignore gnu global files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ DragonUnPACKer-Doc/*
 !DragonUnPACKer-Doc/*.tex
 !DragonUnPACKer-Doc/*.pdf
 !DragonUnPACKer-Doc/images/
+
+# GNU global files used for functions lookup in Lazarus on Linux
+GPATH
+GRTAGS
+GTAGS


### PR DESCRIPTION
When working with Lazarus on Linux (or possibly on any system with an gcc compiler), it requires a gnu `global` program to be installed, to allow indexing files for looking up function definitions/declarations in the editor.

This PR adds files autogenerated by the `global` program to gitignore